### PR TITLE
Set proper environment inside of a compiled pegjs module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,17 @@
 var fs  = require('fs');
 var peg = require('pegjs');
 
+var options = {
+	cache: false,
+	output: "source",
+	optimize: "speed",
+	trace: false,
+	plugins: []
+};
+
 require.extensions['.pegjs'] = function (module, filename) {
-	module.exports = peg.buildParser(fs.readFileSync(filename, 'utf8'));
+	var source = peg.buildParser(fs.readFileSync(filename, 'utf8'), options);
+	return module._compile("module.exports = " + source + ";\n", filename);
 }
 
 module.exports = peg;


### PR DESCRIPTION
I wrapped compiled parser with [module._compile](http://fredkschott.com/post/2014/06/require-and-the-module-system/#module-compile:1c7b09539349d942ecfae4f79bc4defd) to fix module environment. The main case is to properly set all node.js module-specific globals:
- `require`
- `module`
- `__filename`
- `__dirname`

It will allow you to `require` any helper module inside of a `.pegjs` file by it's relative path, just like you normally do with any ordinary `.js` module, e.g.:

``` pegjs
{
  const myHelpers = require('./my-helpers')
}

start = char:( 'a' / 'b' )+ { return myHelpers.foo(char) }
```
